### PR TITLE
[6주차] 최예빈/[feat] 로그인/회원가입 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,7 +4,7 @@ export default function App() {
   return (
     <div className='min-h-screen bg-gray-100 flex justify-center py-14'>
       <div className='w-[600px] bg-white rounded-sm p-10 shadow-[var(--shadow-card)]'>
-        <TodoContaier />
+        <TodoContainer />
       </div>
     </div>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import TodoContaier from './containers/TodoContainer';
+import TodoContainer from './containers/TodoContainer';
 
 export default function App() {
   return (

--- a/src/containers/TodoContainer.jsx
+++ b/src/containers/TodoContainer.jsx
@@ -4,7 +4,7 @@ import AddTodo from '../components/todo/AddTodo';
 import Category from '../components/todo/Category';
 import TodoList from '../components/todo/TodoList';
 
-export default function TodoContaier() {
+export default function TodoContainer() {
   const [tasks, setTasks] = useState(() => {
     const saved = localStorage.getItem('tasks');
     return saved ? JSON.parse(saved) : [];

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,23 @@
-import { StrictMode } from 'react'
-import { createRoot } from 'react-dom/client'
-import './index.css'
-import App from './App.jsx'
+// src/main.jsx
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import { createBrowserRouter, RouterProvider } from 'react-router-dom';
+import App from './App.jsx';
+import Home from './pages/Home.jsx';
+import Login from './pages/Login.jsx';
+import Signup from './pages/Signup.jsx';
+import ErrorPage from './pages/ErrorPage.jsx';
+import './index.css';
+
+const router = createBrowserRouter([
+  { path: '/', element: <Home />, errorElement: <ErrorPage /> },
+  { path: '/login', element: <Login /> },
+  { path: '/signup', element: <Signup /> },
+  { path: '/todo', element: <App /> },
+]);
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <App />
+    <RouterProvider router={router} />
   </StrictMode>,
-)
+);

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -4,7 +4,7 @@ export default function ErrorPage() {
   return (
     <div className='min-h-screen flex flex-col items-center justify-center bg-red-50 text-red-700'>
       <h1 className='text-3xl font-bold mb-4'>404 Not Found</h1>
-      <o>페이지를 찾을 수 없습니다.</o>
+      <p>페이지를 찾을 수 없습니다.</p>
       <Link to='/' className='mt-6 underline'>
         홈으로 돌아가기
       </Link>

--- a/src/pages/ErrorPage.jsx
+++ b/src/pages/ErrorPage.jsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom';
+
+export default function ErrorPage() {
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center bg-red-50 text-red-700'>
+      <h1 className='text-3xl font-bold mb-4'>404 Not Found</h1>
+      <o>페이지를 찾을 수 없습니다.</o>
+      <Link to='/' className='mt-6 underline'>
+        홈으로 돌아가기
+      </Link>
+    </div>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,0 +1,27 @@
+import { Link } from 'react-router-dom';
+import Button from '../components/common/Button';
+import Text from '../components/common/Text';
+
+export default function Home() {
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center bg-white'>
+      <Text as='h1' className='text-3xl font-extrabold mb-10 tracking-tight'>
+        예빈&apos;s TODO
+      </Text>
+
+      <div className='flex flex-col gap-4 w-[200px]'>
+        <Link to='/login'>
+          <Button className='w-full py-3 !rounded-full !bg-gray-200 text-black font-semibold hover:bg-gray-300 transition-colors duration-200 border-none'>
+            로그인
+          </Button>
+        </Link>
+
+        <Link to='/signup'>
+          <Button className='w-full py-3 !rounded-full !bg-gray-200 text-black font-semibold hover:bg-gray-300 transition-colors duration-200 border-none'>
+            회원가입
+          </Button>
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -1,0 +1,75 @@
+import { useNavigate, Link } from 'react-router-dom';
+import Input from '../components/common/Input';
+import Button from '../components/common/Button';
+import Text from '../components/common/Text';
+import { useState } from 'react';
+
+export default function Login() {
+  const navigate = useNavigate();
+  const [id, setId] = useState('');
+  const [pw, setPw] = useState('');
+
+  const handleLogin = () => {
+    if (!id || !pw) {
+      alert('아이디와 비밀번호를 입력하세요.');
+      return;
+    }
+    navigate('/todo');
+  };
+
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center bg-gray-50'>
+      <div className='bg-white p-10 rounded-lg shadow-md w-[400px]'>
+        <Text as='h2' className='text-2xl font-bold mb-8 text-center'>
+          로그인
+        </Text>
+
+        <div className='flex flex-col gap-4 mb-6'>
+          <div className='flex items-center justify-between gap-3'>
+            <label htmlFor='id' className='w-20 text-right font-medium text-gray-700'>
+              아이디
+            </label>
+            <Input
+              id='id'
+              placeholder='아이디를 입력하세요'
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              className='flex-1 border-gray-400'
+            />
+          </div>
+
+          <div className='flex items-center justify-between gap-3'>
+            <label htmlFor='pw' className='w-20 text-right font-medium text-gray-700'>
+              비밀번호
+            </label>
+            <Input
+              id='pw'
+              type='password'
+              placeholder='비밀번호를 입력하세요'
+              value={pw}
+              onChange={(e) => setPw(e.target.value)}
+              className='flex-1 border-gray-400'
+            />
+          </div>
+        </div>
+
+        <div className='flex justify-end mb-6'>
+          <Button
+            variant='primary'
+            className='w-full flex item-center justify-center leading-none bg-gray-700 text-white border-none hover:bg-gray-800 transition'
+            onClick={handleLogin}
+          >
+            로그인
+          </Button>
+        </div>
+
+        <p className='text-center text-gray-600 text-sm'>
+          아직 회원이 아니신가요?{' '}
+          <Link to='/signup' className='text-blue-600 underline'>
+            회원가입
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/Signup.jsx
+++ b/src/pages/Signup.jsx
@@ -1,0 +1,90 @@
+import { useState } from 'react';
+import { Link, useNavigate } from 'react-router-dom';
+import Input from '../components/common/Input';
+import Button from '../components/common/Button';
+import Text from '../components/common/Text';
+
+export default function Signup() {
+  const navigate = useNavigate();
+  const [name, setName] = useState('');
+  const [id, setId] = useState('');
+  const [pw, setPw] = useState('');
+
+  const handleSignup = () => {
+    if (!name || !id || !pw) {
+      alert('모든 항목을 입력하세요.');
+      return;
+    }
+    alert('회원가입 완료!');
+    navigate('/login');
+  };
+
+  return (
+    <div className='min-h-screen flex flex-col items-center justify-center bg-gray-50'>
+      <div className='bg-white p-10 rounded-lg shadow-md w-[420px]'>
+        <Text as='h2' className='text-2xl font-bold mb-8 text-center'>
+          회원가입
+        </Text>
+
+        <div className='flex flex-col gap-4 mb-6'>
+          <div className='flex items-center justify-between gap-3'>
+            <label htmlFor='name' className='w-20 text-right font-medium text-gray-700'>
+              이름
+            </label>
+            <Input
+              id='name'
+              placeholder='이름을 입력하세요'
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              className='flex-1 border-gray-400'
+            />
+          </div>
+
+          <div className='flex items-center justify-between gap-3'>
+            <label htmlFor='id' className='w-20 text-right font-medium text-gray-700'>
+              아이디
+            </label>
+            <Input
+              id='id'
+              placeholder='아이디를 입력하세요'
+              value={id}
+              onChange={(e) => setId(e.target.value)}
+              className='flex-1 border-gray-400'
+            />
+          </div>
+
+          <div className='flex items-center justify-between gap-3'>
+            <label htmlFor='pw' className='w-20 text-right font-medium text-gray-700'>
+              비밀번호
+            </label>
+            <Input
+              id='pw'
+              type='password'
+              placeholder='비밀번호를 입력하세요'
+              value={pw}
+              onChange={(e) => setPw(e.target.value)}
+              className='flex-1 border-gray-400'
+            />
+          </div>
+        </div>
+
+        <div className='flex justify-end mb-6'>
+          <Button
+            variant='primary'
+            className='w-full flex item-center justify-center leading-none bg-gray-700 text-white border-none hover:bg-gray-800 transition'
+            onClick={handleSignup}
+          >
+            회원가입
+          </Button>
+        </div>
+
+        <p className='text-center text-gray-600 text-sm'>
+          이미 계정이 있으신가요?{' '}
+          <Link to='/login' className='text-blue-600 underline'>
+            로그인
+          </Link>
+        </p>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## 1. 무슨 이유로 코드를 변경했나요?

로그인/회원가입 UI 구현 및 라우팅 구조 분리 작업을 진행했습니다.
- `/` 루트 페이지 -> 로그인/회원가입 버튼 표시
- `/login` 로그인 페이지 -> 아이디/비밀번호 입력 후 Todo 페이지 (`/todo`)로 이동
- `/signup` 회원가입 페이지 -> 이름/아이디/비밀번호 입력 후 로그인 페이지(`/login`)로 이동
- `/todo` Todo 페이지 연결
- 이외 -> ErrorPage 연결

<br>

## 2. 어떤 위험이나 장애를 발견했나요?

- `App.jsx`에서 `TodoContainer` 오타로 인해 `/todo` 페이지 진입 시 에러가 발생했습니다. 따라서 컴포넌트명과 import 경로를 일치시켜 정상적으로 연결했습니다!
- `Button` 컴포넌트의 기본 `bg-white` 스타일이 우선 적용되어 Home 페이지의 회색 버튼 색상이 보이지 않는 문제가 있었습니다. 따라서 Tailwind의 `!` prefix를 적용하여 해결했습니다!

<br>

## 3. 관련 스크린샷을 첨부해주세요.
<img width="315" height="318" alt="image" src="https://github.com/user-attachments/assets/1fd716ae-16c1-4ae7-9237-913bf191da5b" />

루트 페이지 (`/`)

<img width="393" height="335" alt="image" src="https://github.com/user-attachments/assets/a2f98ea6-f556-43c4-8085-fd046e41e61a" />

로그인 페이지 (`/login`)

<img width="401" height="389" alt="image" src="https://github.com/user-attachments/assets/365d6ae0-4177-40b0-8a12-8aed810e9344" />

회원가입 페이지 (`/signup`)

<br>

## 4. 완료 사항
- `/`, `/login`, `/signup`, `/todo` 라우팅 구성
- Home 페이지(루트) UI 구현
- 로그인 페이지 UI 구현
- 회원가입 페이지 UI 구현
- Todo 페이지와 기존 TodoContainer 연결
- ErrorPage 추가 및 기본 예외 처리 적용


<br>

## 5. 추가 사항
UX 개선을 위해 ErrorPage(404 페이지)를 추가했습니다! 잘못된 경로 접근 시 간단한 안내문구와 홈으로 돌아가기 링크가 표시됩니다.

closed #43 
